### PR TITLE
DYN-5219-Dismiss-feature-notification-icon-should-mark-as-read

### DIFF
--- a/packages/notifications-panel/package.json
+++ b/packages/notifications-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/notifications-panel",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "HIG NotificationsPanel",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/notifications-panel/src/Notification.js
+++ b/packages/notifications-panel/src/Notification.js
@@ -28,12 +28,12 @@ const Notification = (props) => {
     onNotificationClick,
     onMouseEnter,
     onMouseLeave,
-    // Featured notifications show the dismiss button by default
-    showDismissButton = featured,
     stylesheet,
     timestamp,
     type,
     unread,
+    // Notifications dismiss button will be displayed in case unread || feature is true
+    showDismissButton = unread && featured,
     ...otherProps
   } = props;
   const { className } = otherProps;

--- a/packages/notifications-panel/src/NotificationsPanel.js
+++ b/packages/notifications-panel/src/NotificationsPanel.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState, useEffect} from "react";
 import Panel from "./Panel";
 import Notification from "./Notification";
 import EmptyStatePresenter from "./presenters/EmptyStatePresenter";
@@ -77,18 +77,40 @@ export default function NotificationsPanel(props) {
     markAllAsReadTitle,
     onClickMarkAllAsRead,
     onNotificationChanged,
-    notifications: notificationsInput = children,
+    notifications,
     unreadCount: controlledUnreadCount,
     stylesheet,
     ...otherProps
   } = props;
   const { className } = otherProps;
 
+  const [notificationsInput, setNotificationsInput] = useState([]);
+
+  useEffect(()=> {
+    setNotificationsInput(notifications);
+  }, []);
+
+  const markNotificationAsRead = (id) => {
+
+    const updatedNotifications = notificationsInput.map(notification => {
+      if(notification.id !== id) return notification;
+      return {
+        ...notification,
+        featured: false,
+        unread: false
+      }
+    })
+
+    setNotificationsInput(updatedNotifications);
+  }
+
   return (
     <NotificationFlyoutBehavior
       unreadCount={controlledUnreadCount}
       notifications={notificationsInput}
       notificationChanged={onNotificationChanged}
+      markNotificationAsRead = {markNotificationAsRead}
+      setNotifications = {setNotificationsInput}
     >
       {({
         dismissNotification,

--- a/packages/notifications-panel/src/NotificationsPanel.js
+++ b/packages/notifications-panel/src/NotificationsPanel.js
@@ -96,7 +96,6 @@ export default function NotificationsPanel(props) {
       if(notification.id !== id) return notification;
       return {
         ...notification,
-        featured: false,
         unread: false
       }
     })
@@ -125,10 +124,10 @@ export default function NotificationsPanel(props) {
           heading={heading}
           unreadCount={unreadCount}
           >
-          {notifications.length == 0 ? (
+          {unreadCount === 0 ? (
             <EmptyStatePresenter title={emptyTitle} message={emptyMessage} image={emptyImage} stylesheet={stylesheet} />
           ) : (
-            notifications.map(
+            notificationsInput.map(
               CreateNotificationRenderer({ dismissNotification })
             )
           )}

--- a/packages/notifications-panel/src/behaviors/NotificationBehavior.js
+++ b/packages/notifications-panel/src/behaviors/NotificationBehavior.js
@@ -57,7 +57,10 @@ const NotificationBehavior = (props) => {
   };
 
   const handleDismissButtonClick = () => {
-    hide();
+
+    console.log("DISMISSED");
+    handleExit();
+    // hide()
   };
 
   const innerRef = refContainer;

--- a/packages/notifications-panel/src/behaviors/NotificationBehavior.js
+++ b/packages/notifications-panel/src/behaviors/NotificationBehavior.js
@@ -57,10 +57,8 @@ const NotificationBehavior = (props) => {
   };
 
   const handleDismissButtonClick = () => {
-
-    console.log("DISMISSED");
+    hide();
     handleExit();
-    // hide()
   };
 
   const innerRef = refContainer;

--- a/packages/notifications-panel/src/behaviors/NotificationFlyoutBehavior.js
+++ b/packages/notifications-panel/src/behaviors/NotificationFlyoutBehavior.js
@@ -88,9 +88,10 @@ export default class NotificationFlyoutBehavior extends Component {
    * @param {string} id
    */
   dismissNotification = (id) => {
-    this.setState({
-      // eslint-disable-next-line react/no-access-state-in-setstate
-      dismissedNotifications: this.state.dismissedNotifications.concat(id),
+    this.setState((prevState) => {
+      const updatedNotifications = prevState.dismissedNotifications.includes(id);
+      if(updatedNotifications) return;
+      return { dismissedNotifications: prevState.dismissedNotifications.concat(id) }
     });
     this.props.markNotificationAsRead(id);
     // This function let NotificationCenter knows about any change done in NotificationsPanel
@@ -121,7 +122,6 @@ export default class NotificationFlyoutBehavior extends Component {
       if(notification.unread === false) return notification;
       return {
         ...notification,
-        featured: false,
         unread: false
       }
     })


### PR DESCRIPTION
This PR implements a solution for [DYN-5219](https://jira.autodesk.com/browse/DYN-5219)
Now, anytime we dismiss a notification it will be mark as read and will be removed from the list.

![DYN-5219](https://github.com/DynamoDS/hig/assets/111511512/16ca8386-f535-4237-920c-0353d27d4e5a)


**FYI**
@QilongTang 
@RobertGlobant20 