### PR TITLE
Fix/DYN 5219 dismiss notification icon should mark as read

### DIFF
--- a/packages/notifications-panel/package.json
+++ b/packages/notifications-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/notifications-panel",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "HIG NotificationsPanel",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/notifications-panel/src/Notification.js
+++ b/packages/notifications-panel/src/Notification.js
@@ -32,7 +32,7 @@ const Notification = (props) => {
     timestamp,
     type,
     unread,
-    // Notifications dismiss button will be displayed in case unread is true
+    // Notifications dismiss button will be displayed in case featured is true
     showDismissButton = featured,
     ...otherProps
   } = props;

--- a/packages/notifications-panel/src/Notification.js
+++ b/packages/notifications-panel/src/Notification.js
@@ -32,8 +32,8 @@ const Notification = (props) => {
     timestamp,
     type,
     unread,
-    // Notifications dismiss button will be displayed in case unread || feature is true
-    showDismissButton = unread && featured,
+    // Notifications dismiss button will be displayed in case unread is true
+    showDismissButton = featured,
     ...otherProps
   } = props;
   const { className } = otherProps;

--- a/packages/notifications-panel/src/NotificationsPanel.js
+++ b/packages/notifications-panel/src/NotificationsPanel.js
@@ -75,7 +75,7 @@ export default function NotificationsPanel(props) {
     onScroll,
     open,
     markAllAsReadTitle,
-    onClickMarkAllAsRead,
+    markAsRead,
     onNotificationChanged,
     notifications,
     unreadCount: controlledUnreadCount,
@@ -88,39 +88,41 @@ export default function NotificationsPanel(props) {
 
   useEffect(()=> {
     setNotificationsInput(notifications);
-  }, []);
+    this.props.notificationChanged();
+  }, [notifications]);
 
-  const markNotificationAsRead = (id) => {
+  // const markNotificationAsRead = (id) => {
+  //   // Here might be an error
+  //   const updatedNotifications = notificationsInput.map(notification => {
+  //     if(notification.id !== id) return notification;
+  //     return {
+  //       ...notification,
+  //       unread: false
+  //     }
+  //   })
 
-    const updatedNotifications = notificationsInput.map(notification => {
-      if(notification.id !== id) return notification;
-      return {
-        ...notification,
-        unread: false
-      }
-    })
-
-    setNotificationsInput(updatedNotifications);
-  }
+  //   setNotificationsInput(updatedNotifications);
+  // }
 
   return (
     <NotificationFlyoutBehavior
       unreadCount={controlledUnreadCount}
       notifications={notificationsInput}
       notificationChanged={onNotificationChanged}
-      markNotificationAsRead = {markNotificationAsRead}
+      markAsRead = {markAsRead}
       setNotifications = {setNotificationsInput}
     >
       {({
         dismissNotification,
         handleClose,
         notifications,
-        unreadCount
+        unreadCount,
+        markAllNotificationsAsRead
       }) => (
         <Panel
           innerRef={() => { }}
           markAllAsReadTitle={markAllAsReadTitle}
-          onClickMarkAllAsRead={onClickMarkAllAsRead}
+          onClickMarkAllAsRead={markAllNotificationsAsRead}
           heading={heading}
           unreadCount={unreadCount}
           >

--- a/packages/notifications-panel/src/NotificationsPanel.js
+++ b/packages/notifications-panel/src/NotificationsPanel.js
@@ -88,21 +88,8 @@ export default function NotificationsPanel(props) {
 
   useEffect(()=> {
     setNotificationsInput(notifications);
-    this.props.notificationChanged();
+    onNotificationChanged();
   }, [notifications]);
-
-  // const markNotificationAsRead = (id) => {
-  //   // Here might be an error
-  //   const updatedNotifications = notificationsInput.map(notification => {
-  //     if(notification.id !== id) return notification;
-  //     return {
-  //       ...notification,
-  //       unread: false
-  //     }
-  //   })
-
-  //   setNotificationsInput(updatedNotifications);
-  // }
 
   return (
     <NotificationFlyoutBehavior
@@ -126,12 +113,12 @@ export default function NotificationsPanel(props) {
           heading={heading}
           unreadCount={unreadCount}
           >
-          {unreadCount === 0 ? (
-            <EmptyStatePresenter title={emptyTitle} message={emptyMessage} image={emptyImage} stylesheet={stylesheet} />
-          ) : (
+          {unreadCount > 0 ? (
             notificationsInput.map(
               CreateNotificationRenderer({ dismissNotification })
             )
+            ) : (
+            <EmptyStatePresenter title={emptyTitle} message={emptyMessage} image={emptyImage} stylesheet={stylesheet} />
           )}
         </Panel>
       )}

--- a/packages/notifications-panel/src/behaviors/NotificationFlyoutBehavior.js
+++ b/packages/notifications-panel/src/behaviors/NotificationFlyoutBehavior.js
@@ -53,25 +53,45 @@ export default class NotificationFlyoutBehavior extends Component {
   /** @type {State} */
   // eslint-disable-next-line react/state-in-constructor
   state = {
+    notifications: [],
     dismissedNotifications: [],
     readNotifications: [],
   };
 
   /**
+   * @param {Props} nextProps
+   * @returns {State | null}
+   */
+  static getDerivedStateFromProps(nextProps) {
+    return {
+      notifications: nextProps.notifications,
+      // notifications: parseNotifications(nextProps.notifications),
+    };
+  }
+
+  /**
    * @returns {ParsedNotification[]}
    */
+  // getNotifications() {
+  //   const { dismissedNotifications, readNotifications } =
+  //     this.state;
+
+  //   const updateReadStatus = ({ id, unread, ...otherProps }) => ({
+  //     id,
+  //     unread: unread && !readNotifications.includes(id),
+  //     ...otherProps,
+  //   });
+  //   const isNotDismissed = ({ id }) => !dismissedNotifications.includes(id);
+
+  //   return this.props.notifications.map(updateReadStatus).filter(isNotDismissed);
+  // }
+
   getNotifications() {
-    const { dismissedNotifications, readNotifications } =
-      this.state;
+    const { notifications } = this.state;
+    const unreadNotifications = this.props.notifications.filter(
+      notification => notification.unread === true);
 
-    const updateReadStatus = ({ id, unread, ...otherProps }) => ({
-      id,
-      unread: unread && !readNotifications.includes(id),
-      ...otherProps,
-    });
-    const isNotDismissed = ({ id }) => !dismissedNotifications.includes(id);
-
-    return this.props.notifications.map(updateReadStatus).filter(isNotDismissed);
+    return unreadNotifications;
   }
 
   /** @returns {number} */
@@ -88,22 +108,17 @@ export default class NotificationFlyoutBehavior extends Component {
    * @param {string} id
    */
   dismissNotification = (id) => {
-    this.setState((prevState) => {
-      const updatedNotifications = prevState.dismissedNotifications.includes(id);
-      if(updatedNotifications) return;
-      return { dismissedNotifications: prevState.dismissedNotifications.concat(id) }
-    });
-    this.props.markNotificationAsRead(id);
+    this.props.markAsRead(id);
     // This function let NotificationCenter knows about any change done in NotificationsPanel
     // so then we could trigger the function that shares the NotificationCenter height to Dynamo
-    this.props.notificationChanged();
+    // this.props.notificationChanged();
   };
 
   /**
    * Handler for when the flyout opens
    */
   handleClose = () => {
-    this.markAllNotificationsRead();
+    // this.markAllNotificationsRead();
   };
 
   /**
@@ -116,17 +131,13 @@ export default class NotificationFlyoutBehavior extends Component {
     );
   }
 
-  markAllNotificationsAsRead() {
+  markAllNotificationsAsRead = () => {
     const notifications = this.getNotifications();
-    const updatedNotifications = notifications.map(notification => {
-      if(notification.unread === false) return notification;
-      return {
-        ...notification,
-        unread: false
-      }
-    })
-    this.setNotificationsInput(updatedNotifications);
-    this.setState({ readNotifications: updatedNotifications.map(notification => notification.id) });
+    const unreadNotificationsIDs = notifications.map(notification => notification.id);
+    this.props.markAsRead(unreadNotificationsIDs)
+    // This function let NotificationCenter knows about any change done in NotificationsPanel
+    // so then we could trigger the function that shares the NotificationCenter height to Dynamo
+    // this.props.notificationChanged();
   }
   /**
    * @returns {import("react").ReactElement}
@@ -136,6 +147,7 @@ export default class NotificationFlyoutBehavior extends Component {
     const notifications = this.props.notifications;
     const unreadCount = this.getUnreadCount();
     const showUnreadCount = unreadCount > 0;
+    const markAllNotificationsAsRead = this.markAllNotificationsAsRead;
 
     return this.props.children({
       dismissNotification,
@@ -143,6 +155,7 @@ export default class NotificationFlyoutBehavior extends Component {
       notifications,
       showUnreadCount,
       unreadCount,
+      markAllNotificationsAsRead
     });
   }
 }

--- a/packages/notifications-panel/src/behaviors/NotificationFlyoutBehavior.js
+++ b/packages/notifications-panel/src/behaviors/NotificationFlyoutBehavior.js
@@ -72,19 +72,6 @@ export default class NotificationFlyoutBehavior extends Component {
   /**
    * @returns {ParsedNotification[]}
    */
-  // getNotifications() {
-  //   const { dismissedNotifications, readNotifications } =
-  //     this.state;
-
-  //   const updateReadStatus = ({ id, unread, ...otherProps }) => ({
-  //     id,
-  //     unread: unread && !readNotifications.includes(id),
-  //     ...otherProps,
-  //   });
-  //   const isNotDismissed = ({ id }) => !dismissedNotifications.includes(id);
-
-  //   return this.props.notifications.map(updateReadStatus).filter(isNotDismissed);
-  // }
 
   getNotifications() {
     const { notifications } = this.state;
@@ -109,9 +96,6 @@ export default class NotificationFlyoutBehavior extends Component {
    */
   dismissNotification = (id) => {
     this.props.markAsRead(id);
-    // This function let NotificationCenter knows about any change done in NotificationsPanel
-    // so then we could trigger the function that shares the NotificationCenter height to Dynamo
-    // this.props.notificationChanged();
   };
 
   /**
@@ -134,10 +118,7 @@ export default class NotificationFlyoutBehavior extends Component {
   markAllNotificationsAsRead = () => {
     const notifications = this.getNotifications();
     const unreadNotificationsIDs = notifications.map(notification => notification.id);
-    this.props.markAsRead(unreadNotificationsIDs)
-    // This function let NotificationCenter knows about any change done in NotificationsPanel
-    // so then we could trigger the function that shares the NotificationCenter height to Dynamo
-    // this.props.notificationChanged();
+    this.props.markAsRead(unreadNotificationsIDs);
   }
   /**
    * @returns {import("react").ReactElement}

--- a/packages/notifications-panel/src/behaviors/NotificationFlyoutBehavior.js
+++ b/packages/notifications-panel/src/behaviors/NotificationFlyoutBehavior.js
@@ -65,7 +65,6 @@ export default class NotificationFlyoutBehavior extends Component {
   static getDerivedStateFromProps(nextProps) {
     return {
       notifications: nextProps.notifications,
-      // notifications: parseNotifications(nextProps.notifications),
     };
   }
 
@@ -101,9 +100,7 @@ export default class NotificationFlyoutBehavior extends Component {
   /**
    * Handler for when the flyout opens
    */
-  handleClose = () => {
-    // this.markAllNotificationsRead();
-  };
+  handleClose = () => {};
 
   /**
    * @param {ParsedNotification[]} notifications


### PR DESCRIPTION
This PR implements a fix for the Notifications-Panel v 0.0.7 regarding to [DYN-5219](https://jira.autodesk.com/browse/DYN-5219). 
Anytime we dismiss a notification it will be mark as read and will be removed from the list.

![DYN-5219-gif](https://github.com/DynamoDS/hig/assets/111511512/7634ec47-438b-409a-a399-0c51f1d5ea50)

**FYI**
@QilongTang 
@reddyashish 
@RobertGlobant20 