### PR TITLE
[DYN-5217] feature: improve notifications panel visual hierarchy

### DIFF
--- a/packages/notifications-panel/package.json
+++ b/packages/notifications-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/notifications-panel",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "HIG NotificationsPanel",
   "author": "Autodesk Inc.",
   "license": "Apache-2.0",

--- a/packages/notifications-panel/src/presenters/NotificationPresenter.js
+++ b/packages/notifications-panel/src/presenters/NotificationPresenter.js
@@ -76,7 +76,11 @@ export default function NotificationPresenter(props) {
                   css(styles.notificationContentText),
                 ])}
               >
-                <RichText size="small">{children}</RichText>
+                <RichText size="small" 
+                  className={cx([className, 
+                  css(styles.notificationDescription)])}>
+                    {children}
+                </RichText>
                 {timestamp}
                 {showDismissButton ? (
                   <DismissButtonPresenter

--- a/packages/notifications-panel/src/presenters/stylesheet.js
+++ b/packages/notifications-panel/src/presenters/stylesheet.js
@@ -75,11 +75,26 @@ export default function stylesheet(props, themeData) {
       margin: `${themeData["density.spacings.small"]}`,
       wordWrap: `break-word`,
       overflow: `hidden`,
+      b: {
+        fontSize: '12px',
+        fontWeight: 'bold'
+      },
+      a: {
+        fontSize: '12px',
+        fontWeight: '200'
+      },
+    },
+    notificationDescription: {
+      p: {
+        fontSize: '12px',
+        fontWeight: '200'
+      }
     },
     panelTitle: {
       padding: `${themeData["density.spacings.small"]}
         ${themeData["density.spacings.large"]}`,
       borderBottom: `1px solid ${themeData["divider.heavyColor"]}`,
+      fontWeight: 'bold'
     },
     panelContainer: {
       width: `100%`,


### PR DESCRIPTION
Ref.: [DYN-5217](https://jira.autodesk.com/browse/)

Adjust visual hierarchy based on specs:

- Notifications (Header Title): Artifakt Element, 14, bold (Weave token: basics.fontSizes.medium/Medium/bold)

- Title of each notification: Artifakt Element, 12, bold (Weave token: basics.fontSizes.medium/Small/bold)
 
- Notification details: Artifakt Element, 12, regular (Weave token: basics.fontSizes.medium/Small/regular)
 
- Links: Artifakt Element, 12, regular (Weave token: basics.fontSizes.medium/Small/regular)

**before:**
![image](https://github.com/DynamoDS/hig/assets/111511512/1557876d-1a63-4f7c-a1d8-fe078d1711d7)

**After**
![image](https://github.com/DynamoDS/hig/assets/111511512/ec52e21e-c677-46b4-87a7-b2d83911bc7a)
